### PR TITLE
Move away from deprecated Electron require syntax

### DIFF
--- a/lib/link.coffee
+++ b/lib/link.coffee
@@ -1,5 +1,6 @@
 url = require 'url'
-shell = require 'shell'
+# TODO: Remove the catch once Atom 1.7.0 is released
+try {shell} = require 'electron' catch then shell = require 'shell'
 _ = require 'underscore-plus'
 
 selector = null

--- a/spec/link-spec.coffee
+++ b/spec/link-spec.coffee
@@ -1,4 +1,5 @@
-shell = require 'shell'
+# TODO: Remove the catch once Atom 1.7.0 is released
+try {shell} = require 'electron' catch then shell = require 'shell'
 
 describe "link package", ->
   beforeEach ->


### PR DESCRIPTION
Required for atom/atom#10983.