### PR TITLE
Add notes on adding keyboard shortcut on Windows or Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,18 @@
 [![OS X Build Status](https://travis-ci.org/atom/link.png?branch=master)](https://travis-ci.org/atom/link) [![Windows Build Status](https://ci.appveyor.com/api/projects/status/1d3cb8ktd48k9vnl/branch/master?svg=true)](https://ci.appveyor.com/project/Atom/link/branch/master) [![Dependency Status](https://david-dm.org/atom/link.svg)](https://david-dm.org/atom/link)
 
 Opens http(s) links under the cursor using <kbd>ctrl-shift-o</kbd>.
+
+---
+
+Linux or Windows users can add the following line to their `keymap.cson` under the `'atom-workspace'` key to open links with <kbd>alt-o</kbd>:
+
+```
+  'alt-o': 'link:open'
+```
+
+If you do not have an `'atom-workspace'` key in `keymap.cson`, add the following section:
+
+```
+'atom-workspace':
+  'alt-o': 'link:open'
+```


### PR DESCRIPTION
To make GH-9 less of an issue, this adds configuration instructions for using this package on non-macOS platforms.

### Description of the Change

This is only a documentation change.

### Alternate Designs

This could be effective by adding a sensible default on non-macOS systems, but no consensus was mentioned by package maintainers on #9.

### Benefits

This will make it easier for new Windows and Linux users of this package to configure it on their machines.

### Possible Drawbacks

This is not an automatic fix and will require manual intervention by the end users.

### Applicable Issues

This was a solution proposed several times on #9.
