### PR TITLE
Improve keybinding documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 # Link package
-[![OS X Build Status](https://travis-ci.org/atom/link.png?branch=master)](https://travis-ci.org/atom/link) [![Windows Build Status](https://ci.appveyor.com/api/projects/status/1d3cb8ktd48k9vnl/branch/master?svg=true)](https://ci.appveyor.com/project/Atom/link/branch/master) [![Dependency Status](https://david-dm.org/atom/link.svg)](https://david-dm.org/atom/link)
+[![macOS Build Status](https://travis-ci.org/atom/link.svg?branch=master)](https://travis-ci.org/atom/link) [![Windows Build Status](https://ci.appveyor.com/api/projects/status/1d3cb8ktd48k9vnl/branch/master?svg=true)](https://ci.appveyor.com/project/Atom/link/branch/master) [![Dependency Status](https://david-dm.org/atom/link.svg)](https://david-dm.org/atom/link)
 
-Opens http(s) links under the cursor using <kbd>ctrl-shift-o</kbd>.
+Opens http(s) links under the cursor.
+
+### Commands and Keybindings
+
+|Command|Selector|Description|Keybinding (Linux)|Keybinding (macOS)|Keybinding (Windows)|
+|-------|--------|-----------|------------------|------------------|--------------------|
+|`link:open`|`atom-text-editor`|Opens the http(s) link under the cursor||<kbd>ctrl-shift-o</kbd>||
+Custom keybindings can be added by referencing the above commands.  To learn more, visit the [Using Atom: Basic Customization](http://flight-manual.atom.io/using-atom/sections/basic-customization/#customizing-keybindings) or [Behind Atom: Keymaps In-Depth](http://flight-manual.atom.io/behind-atom/sections/keymaps-in-depth) sections of the Atom Flight Manual.

--- a/README.md
+++ b/README.md
@@ -8,4 +8,5 @@ Opens http(s) links under the cursor.
 |Command|Selector|Description|Keybinding (Linux)|Keybinding (macOS)|Keybinding (Windows)|
 |-------|--------|-----------|------------------|------------------|--------------------|
 |`link:open`|`atom-text-editor`|Opens the http(s) link under the cursor||<kbd>ctrl-shift-o</kbd>||
+
 Custom keybindings can be added by referencing the above commands.  To learn more, visit the [Using Atom: Basic Customization](http://flight-manual.atom.io/using-atom/sections/basic-customization/#customizing-keybindings) or [Behind Atom: Keymaps In-Depth](http://flight-manual.atom.io/behind-atom/sections/keymaps-in-depth) sections of the Atom Flight Manual.

--- a/keymaps/links.cson
+++ b/keymaps/links.cson
@@ -1,2 +1,2 @@
-'.platform-darwin atom-workspace':
-  'ctrl-O': 'link:open'
+'.platform-darwin atom-text-editor':
+  'ctrl-shift-o': 'link:open'

--- a/lib/link.js
+++ b/lib/link.js
@@ -6,7 +6,7 @@ let selector = null
 
 module.exports = {
   activate () {
-    this.commandDisposable = atom.commands.add('atom-workspace', 'link:open', () => this.openLink())
+    this.commandDisposable = atom.commands.add('atom-text-editor', 'link:open', () => this.openLink())
   },
 
   deactivate () {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "link",
   "version": "0.31.3",
   "main": "./lib/link",
-  "description": "Opens the http/https link under the cursor",
+  "description": "Opens http(s) links under the cursor",
   "license": "MIT",
   "repository": "https://github.com/atom/link",
   "engines": {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Adds a keybinding table to the README that better explains the keybinding situation.  Also links to the Flight Manual for customizing keybindings.

A related change moves the command selector to `atom-text-editor` to better reflect the scenarios in which the command is useful.

### Alternate Designs

Add keybindings for Windows and Linux.  This package isn't utilized often so I think it's better for people who want keybindings to add them themselves.

### Benefits

Less confusion about why `ctrl-shift-o` opens the "Open Folder" dialog on Windows and Linux.

### Possible Drawbacks

None.

### Applicable Issues

Closes #9
Supersedes and closes #22