### PR TITLE
Add link command to context menu when appropriate

### DIFF
--- a/menus/link.cson
+++ b/menus/link.cson
@@ -1,0 +1,4 @@
+'context-menu':
+  'atom-text-editor .syntax--markup.syntax--underline.syntax--link': [
+    {label: 'Open link', command: 'link:open'}
+  ]


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Adds an `Open link` command to the context menu when the cursor is on a link.  How convenient!
![markdown-link-context-menu](https://user-images.githubusercontent.com/2766036/32807392-fa361b30-c98f-11e7-838e-071797f1d9e1.gif)

### Alternate Designs

None.

### Benefits

Easier way to access the link command.

### Possible Drawbacks

It appears at the top of the context menu and I'm not too sure why (maybe specificity?).  May throw off people who use Undo and Redo regularly.

### Applicable Issues

Fixes #16