### PR TITLE
No need to access the buffer when TextEditor APIs suffice

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -21,7 +21,7 @@ module.exports = {
     if (link == null) return
 
     if (editor.getGrammar().scopeName === 'source.gfm') {
-      link = this.linkForName(editor.getBuffer(), link)
+      link = this.linkForName(editor, link)
     }
 
     const {protocol} = url.parse(link)
@@ -66,10 +66,10 @@ module.exports = {
   // ```
   //
   // Returns a {String} link
-  linkForName (buffer, linkName) {
+  linkForName (editor, linkName) {
     let link = linkName
     const regex = new RegExp(`^\\s*\\[${_.escapeRegExp(linkName)}\\]\\s*:\\s*(.+)$`, 'g')
-    buffer.backwardsScanInRange(regex, buffer.getRange(), ({match, stop}) => {
+    editor.backwardsScanInBufferRange(regex, [[0, 0], [Infinity, Infinity]], ({match, stop}) => {
       link = match[1]
       stop()
     })


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The ranges are clipped internally anyway so we don't have to worry about passing excessive ranges.

### Alternate Designs

None.

### Benefits

Just some :art:

### Possible Drawbacks

None.

### Applicable Issues

None.